### PR TITLE
feat: useFunnel custom hook 구현 및 sign-up page 적용

### DIFF
--- a/src/app/(user)/sign-up/page.tsx
+++ b/src/app/(user)/sign-up/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { sendSignupRequest } from '@/api/auth';
-import { Button } from '@/components/ui/Button';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import React, { useState } from 'react';
+import { sendSignupRequest } from '@/api/auth';
+import { useFunnel } from '@/hooks/useFunnel/useFunnel';
+import { Button } from '@/components/ui/Button';
 
 const SignUpPage = () => {
   const { push } = useRouter();
@@ -14,11 +15,9 @@ const SignUpPage = () => {
     password: '',
   });
 
-  const isFormValid = Object.values(formData).every((value) => value !== '');
+  // TODO: submit loading state & disable button
 
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
+  const handleregisterUser = async () => {
     const user = {
       user: {
         ...formData,
@@ -38,6 +37,13 @@ const SignUpPage = () => {
         console.log(err);
       });
   };
+  // TODO: magic number 상수화
+  const [Funnel, activeStepIndex, setStep] = useFunnel(
+    ['username', 'email', 'password'],
+    {
+      initialStep: 'username',
+    },
+  );
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
@@ -45,22 +51,35 @@ const SignUpPage = () => {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
-      <div className="flex-col">
-        <input
-          name="username"
-          placeholder="username"
-          onChange={handleInputChange}
-        />
-        <input name="email" placeholder="email" onChange={handleInputChange} />
-        <input
-          name="password"
-          placeholder="password"
-          onChange={handleInputChange}
-        />
-        <Button disabled={!isFormValid}>Sign Up</Button>
-      </div>
-    </form>
+    <div>
+      <p>{activeStepIndex}</p>
+      <Funnel>
+        <Funnel.Step name="username">
+          <input
+            name="username"
+            placeholder="username"
+            onChange={handleInputChange}
+          />
+          <Button onClick={() => setStep('email')}>다음</Button>
+        </Funnel.Step>
+        <Funnel.Step name="email">
+          <input
+            name="email"
+            placeholder="email"
+            onChange={handleInputChange}
+          />
+          <Button onClick={() => setStep('password')}>다음</Button>
+        </Funnel.Step>
+        <Funnel.Step name="password">
+          <input
+            name="password"
+            placeholder="password"
+            onChange={handleInputChange}
+          />
+          <Button onClick={handleregisterUser}>회원가입</Button>
+        </Funnel.Step>
+      </Funnel>
+    </div>
   );
 };
 

--- a/src/hooks/useFunnel/Funnel.tsx
+++ b/src/hooks/useFunnel/Funnel.tsx
@@ -1,0 +1,27 @@
+import { Children, ReactElement, isValidElement } from 'react';
+import { FunnelProps, NonEmptyArray, StepProps } from './type';
+
+export const Step = <T extends NonEmptyArray<string>>({
+  children,
+}: StepProps<T>) => {
+  return <>{children}</>;
+};
+
+export const Funnel = <Steps extends NonEmptyArray<string>>({
+  steps,
+  step,
+  children,
+}: FunnelProps<Steps>) => {
+  const validChildren = Children.toArray(children)
+    .filter(isValidElement)
+    .filter((i) =>
+      steps.includes((i.props as Partial<StepProps<Steps>>).name ?? ''),
+    ) as Array<ReactElement<StepProps<Steps>>>;
+  const targetStep = validChildren.find((child) => child.props.name === step);
+
+  if (targetStep == null) {
+    throw new Error(`${step} 스텝 컴포넌트를 찾지 못했습니다.`);
+  }
+
+  return <>{targetStep}</>;
+};

--- a/src/hooks/useFunnel/type.ts
+++ b/src/hooks/useFunnel/type.ts
@@ -1,0 +1,16 @@
+import { ReactElement, ReactNode } from 'react';
+
+export type NonEmptyArray<T> = readonly [T, ...T[]];
+
+export interface StepProps<Steps extends NonEmptyArray<string>> {
+  name: Steps[number];
+  children: ReactNode;
+}
+
+export interface FunnelProps<Steps extends NonEmptyArray<string>> {
+  steps: Steps;
+  step: Steps[number];
+  children:
+    | Array<ReactElement<StepProps<Steps>>>
+    | ReactElement<StepProps<Steps>>;
+}

--- a/src/hooks/useFunnel/useFunnel.tsx
+++ b/src/hooks/useFunnel/useFunnel.tsx
@@ -1,0 +1,39 @@
+import { useState, useMemo } from 'react';
+import { Funnel, Step } from './Funnel';
+import { FunnelProps, NonEmptyArray, StepProps } from './type';
+
+type RouteFunnelProps<Steps extends NonEmptyArray<string>> = Omit<
+  FunnelProps<Steps>,
+  'steps' | 'step'
+>;
+
+type FunnelComponent<Steps extends NonEmptyArray<string>> = ((
+  props: RouteFunnelProps<Steps>,
+) => JSX.Element) & {
+  Step: (props: StepProps<Steps>) => JSX.Element;
+};
+
+export const useFunnel = <Steps extends NonEmptyArray<string>>(
+  steps: Steps,
+  options?: { initialStep?: Steps[number] },
+): readonly [
+  FunnelComponent<Steps>,
+  activeStepIndex: number,
+  (step: Steps[number]) => void,
+] => {
+  const [step, setStep] = useState(options?.initialStep ?? steps[0]);
+  const activeStepIndex = steps.findIndex((s) => s === step);
+
+  const FunnelComponent = useMemo(() => {
+    return Object.assign(
+      function RouteFunnel(props: RouteFunnelProps<Steps>) {
+        return <Funnel<Steps> steps={steps} step={step} {...props} />;
+      },
+      {
+        Step,
+      },
+    );
+  }, [step]);
+
+  return [FunnelComponent, activeStepIndex, setStep] as const;
+};


### PR DESCRIPTION
## 📌 이슈 링크
- close #


<br/>

## 📖 작업 배경

- `토스ㅣSLASH 23 - 퍼널: 쏟아지는 페이지 한 방에 관리하기` 영상을 보고 프로젝트에 적용
-  웹에서 회원가입 페이지를  퍼널형식으로 구현하는 건 어울리지 않아 보이지만 이것저것 테스트하는 프로젝트여서  도입
<br/>

## 🛠️ 구현 내용

- useFunnel custom hook 구현
- sign-up page useFunnel custom hook 적용

<br/>

## 💡 참고사항

-

<br/>

## 🖼️ 스크린샷

-

<br/>